### PR TITLE
Fix being unable to place order outside of one page checkout

### DIFF
--- a/view/frontend/templates/checkout/shipping/dpdshipping.phtml
+++ b/view/frontend/templates/checkout/shipping/dpdshipping.phtml
@@ -103,7 +103,7 @@ $checkoutConfig = $checkoutConfigViewModel->getConfig();
             handleButtonClick(event) {
                 const parcelShopId = document.querySelector('.parcelshopId');
 
-                if (!(parcelShopId) || !(parcelShopId.value)) {
+                if (parcelShopId && !(parcelShopId.value)) {
                     event.stopPropagation();
 
                     this.validationError = hyva.str('This is a required field.');


### PR DESCRIPTION
Due to the `event.stopPropagation();` when `.parcelshopId` does not exist on the page any "Place order" action not done inside of a one step checkout would cause `stopPropagation` meaning placing order gets blocked.

I assume the check we would like is "If .parcelshopId is on the page AND it's empty we should throw a validationError" instead of "If .parcelshopId is not on the page OR it's empty we should throw a validationError"